### PR TITLE
[BugFix] employee member 변수 private 으로 이동으로 인한 빌드 에러 수정

### DIFF
--- a/Source/EmployeeManagement/EmployeeManagement.h
+++ b/Source/EmployeeManagement/EmployeeManagement.h
@@ -34,7 +34,7 @@ public:
 	virtual vector<Employee*>* doSearch(string ref) override {
 		vector<Employee*>* foundList_ = new vector<Employee*>(0);
 		for (auto it : *emList_) {
-			if ((*it).name_ == ref) {
+			if ((*it).getName() == ref) {
 				foundList_->push_back(it);
 			}
 		}

--- a/Source/EmployeeManagementTest/EmployeeManagementTest.vcxproj
+++ b/Source/EmployeeManagementTest/EmployeeManagementTest.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{44630693-a600-45d7-a0f3-ff2f37a2fce2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
@@ -38,9 +38,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="EmployeeTest.cpp" />
-    <ClCompile Include="IEmployee.cpp" />
-    <ClCompile Include="IEmployee.h" />
-    <ClCompile Include="MockEmployee.cpp" />
     <ClCompile Include="test.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/Source/UserInterfaceTest/UserInterfaceTest.vcxproj
+++ b/Source/UserInterfaceTest/UserInterfaceTest.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3e01aeeb-15dc-4bc1-b2b2-3c5ccebe8fd0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>


### PR DESCRIPTION
TDD 수행시 priviate 멤버변수 접근으로 에러가 발생하여 public 함수사용으로 변경하였습니다