### PR TITLE
[BugFix] Build warning 제거

### DIFF
--- a/Source/CommandTest/CommandTest.cpp
+++ b/Source/CommandTest/CommandTest.cpp
@@ -188,7 +188,7 @@ TEST_F(CommandTest, SortResultTest ) {
 	for (auto stringLine : command->makeResult(EM, "SCH,-p, , ,certi,PRO")) {
 		resultReal.push_back(stringLine);
 	}
-	resultExpected.push_back("SCH, 88114052, NQ LVARW, CL4, 010 - 4528 - 3059, 19911021, PRO");
+	resultExpected.push_back("SCH,88114052,NQ LVARW,CL4,010-4528-3059,19911021,PRO");
 	resultExpected.push_back("SCH,01122329,DN WD,CL4,010-7174-5680,20071117,PRO");
 	resultExpected.push_back("SCH,03113260,HH LTUPF,CL2,010-5798-5383,19791018,PRO");
 	resultExpected.push_back("SCH,05101762,VCUHLE HMU,CL4,010-3988-9289,20030819,PRO");

--- a/Source/CommandTest/CommandTest.vcxproj
+++ b/Source/CommandTest/CommandTest.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{aa940999-b6fb-4544-ac92-8bcdd9ea2bc8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>

--- a/Source/EmployeeManagement/Command.cpp
+++ b/Source/EmployeeManagement/Command.cpp
@@ -83,7 +83,7 @@ vector<string> Command::employeeResultToString(vector<Employee*>* employeeResult
 }
 
 vector<string> Command::makeResult(EmployeeManagement* EM, const string& commandStr) {
-
+	vector<string> result;
 	vector<string> strList;
 	validChecker_ = new ValidChecker();
 	strList = validChecker_->parseString(commandStr, ",");
@@ -93,9 +93,12 @@ vector<string> Command::makeResult(EmployeeManagement* EM, const string& command
 	for (auto c : commandList) {
 		if (c->type_ == command_type) {
 			c->setCommandString(commandStr);
-			return c->employeeResultToString(c->runCommand(EM));
+			result = c->employeeResultToString(c->runCommand(EM));
+			break;
 		}
 	}
+
+	return result;
 }
 
 vector<Employee*>* AddCommand::runCommand(EmployeeManagement* EM) {

--- a/Source/EmployeeManagement/Search.h
+++ b/Source/EmployeeManagement/Search.h
@@ -44,7 +44,7 @@ public:
 	vector<string>* spiltStr(string ref, string delim) {
 		vector<string>* spiltStr = new vector<string>(0);
 		string token;
-		int spos = 0, len = delim.size(), epos;
+		size_t spos = 0, len = delim.size(), epos;
 
 		while ((epos = ref.find(delim, spos)) != string::npos) {
 			token = ref.substr(spos, epos - spos);

--- a/Source/EmployeeManagementTest/Test_EmployeeManagement.cpp
+++ b/Source/EmployeeManagementTest/Test_EmployeeManagement.cpp
@@ -407,8 +407,6 @@ PURPOSE :
 	See if it handles correctly.
 */
 TEST_F(EmployeeManagementTest, StressTest_01) {
-	Employee* emTemp;
-	vector<Employee*>* emList;
 	for (int i = 0; i < MAX_EMPLOYEE; i++) {
 		emMgmt->addEmployee("1", "em1", "CL1", "010-1354-3734", "19770312", "ADV");
 	}
@@ -425,8 +423,6 @@ PURPOSE :
 */
 TEST_F(EmployeeManagementTest, StressTest_02) {
 	vector <Employee*>* matchingList;
-	Employee* emTemp;
-	vector<Employee*>* emList;
 	for (int i = 0; i < MAX_EMPLOYEE; i++) {
 		emMgmt->addEmployee("1", "em1", "CL1", "010-1354-3734", "19770312", "ADV");
 	}


### PR DESCRIPTION
빌드시 몇가지 warning 이 있어 제거 하는 수정입니다.
unused 변수 선언, return 미선언, type mismatch
command test fail 추가로 수정했습니다