### PR TITLE
[Bugfix] SearchCondPhonenum 생성자에서 searchIdx_ 초기화

### DIFF
--- a/Source/CommandTest/CommandTest.cpp
+++ b/Source/CommandTest/CommandTest.cpp
@@ -25,6 +25,22 @@ protected:
 
 };
 
+TEST_F(CommandTest, ModBugTest) {
+	command->makeResult(EM, "ADD, , , ,85125741,FBAH RTIJ,CL1,010-8900-1478,19780228,ADV");
+
+	for (auto stringLine : command->makeResult(EM, "MOD,-p, , ,phoneNum,010-8900-1478,certi,PRO")) {
+		resultReal.push_back(stringLine);
+	}
+
+	resultExpected.push_back("MOD,85125741,FBAH RTIJ,CL1,010-8900-1478,19780228,ADV");
+
+	ASSERT_EQ(resultReal.size(), resultExpected.size());
+	for (int i = 0; i < resultReal.size(); i++)
+	{
+		EXPECT_EQ(resultReal[i], resultExpected[i]);
+	}
+}
+
 TEST_F(CommandTest, AddTest) {
 	command->makeResult(EM, "ADD, , , ,19129568,SRERLALH HMEF,CL2,010-7260-9521,19640910,PRO");
 	EXPECT_EQ(EM->emList_.size(), 4);

--- a/Source/EmployeeManagement/Search.h
+++ b/Source/EmployeeManagement/Search.h
@@ -133,6 +133,7 @@ public:
 	SearchCondPhonenum(SEARCHTYPE serchType, string refstr) : SearchCond(serchType, refstr) {
 		del_ = "-";
 		fullSearch_ = true;
+		searchIdx_ = PHONEIDX::FIRST_F;
 	}
 	bool setSearchIdx(PHONEIDX idx) {
 		searchIdx_ = idx;
@@ -140,7 +141,7 @@ public:
 		return true;
 	}
 	virtual bool isMatched(string refstr) override {
-		if (fullSearch_) return refstr_ == refstr;
+		if (fullSearch_) return refstr == SearchCond::getReference();
 
 		vector<string>* refStrList = SearchCond::spiltStr(refstr, del_);
 		if (refStrList->size() < 3) {

--- a/Source/EmployeeManagement/Search.h
+++ b/Source/EmployeeManagement/Search.h
@@ -133,7 +133,6 @@ public:
 	SearchCondPhonenum(SEARCHTYPE serchType, string refstr) : SearchCond(serchType, refstr) {
 		del_ = "-";
 		fullSearch_ = true;
-		searchIdx_ = PHONEIDX::FIRST_F;
 	}
 	bool setSearchIdx(PHONEIDX idx) {
 		searchIdx_ = idx;
@@ -141,6 +140,8 @@ public:
 		return true;
 	}
 	virtual bool isMatched(string refstr) override {
+		if (fullSearch_) return refstr_ == refstr;
+
 		vector<string>* refStrList = SearchCond::spiltStr(refstr, del_);
 		if (refStrList->size() < 3) {
 			return false;

--- a/Source/EmployeeManagement/Search.h
+++ b/Source/EmployeeManagement/Search.h
@@ -133,6 +133,7 @@ public:
 	SearchCondPhonenum(SEARCHTYPE serchType, string refstr) : SearchCond(serchType, refstr) {
 		del_ = "-";
 		fullSearch_ = true;
+		searchIdx_ = PHONEIDX::FIRST_F;
 	}
 	bool setSearchIdx(PHONEIDX idx) {
 		searchIdx_ = idx;


### PR DESCRIPTION
searchIdx_ 초기화로 default로 전체 전화번호 비교합니다.